### PR TITLE
LPS-110722

### DIFF
--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -61,6 +61,20 @@ function build_images_dxp_70 {
 		files.liferay.com/private/ee/portal/7.0.10.13/liferay-dxp-digital-enterprise-tomcat-7.0.10.13-sp13-slim-20200310164407389.7z \
 		"" \
 		de-90-7010
+
+	build_image \
+		7.0.10-de-91 \
+		files.liferay.com/private/ee/portal/7.0.10-de-91/liferay-dxp-digital-enterprise-tomcat-7.0.10-de-91-slim-20200420163527702.7z \
+		"" \
+		de-91-7010,hotfix-6871-7010 \
+		files.liferay.com/private/ee/fix-packs/7.0.10/hotfix/liferay-hotfix-6871-7010.zip
+
+	build_image \
+		7.0.10-de-92 \
+		files.liferay.com/private/ee/portal/7.0.10-de-92/liferay-dxp-digital-enterprise-tomcat-7.0.10-de-92-slim-20200519134012683.7z \
+		"" \
+		de-92-7010,hotfix-6854-7010 \
+		files.liferay.com/private/ee/fix-packs/7.0.10/hotfix/liferay-hotfix-6854-7010.zip
 }
 
 function build_images_dxp_71 {

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -179,7 +179,7 @@ function build_images_dxp_72 {
 
 	build_image \
 		7.2.10-sp2 \
-		https://files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-slim-20200511121558464.7z \
+		files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-slim-20200511121558464.7z \
 		"" \
 		dxp-5-7210,hotfix-1467-7210 \
 		files.liferay.com/private/ee/fix-packs/7.2.10/hotfix/liferay-hotfix-1467-7210.zip

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -57,7 +57,7 @@ function build_images_dxp_70 {
 	done
 
 	build_image \
-		7.0.10-sp13,7.0.10-de-90 \
+		7.0.10-de-90,7.0.10-sp13 \
 		files.liferay.com/private/ee/portal/7.0.10.13/liferay-dxp-digital-enterprise-tomcat-7.0.10.13-sp13-slim-20200310164407389.7z \
 		"" \
 		de-90-7010
@@ -100,7 +100,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp1,7.1.10-dxp-5 \
+		7.1.10-dxp-5,7.1.10-sp1 \
 		files.liferay.com/private/ee/portal/7.1.10.1/liferay-dxp-tomcat-7.1.10.1-sp1-20190110085705206.zip \
 		"" \
 		dxp-5-7110
@@ -115,7 +115,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp2,7.1.10-dxp-10 \
+		7.1.10-dxp-10,7.1.10-sp2 \
 		files.liferay.com/private/ee/portal/7.1.10.2/liferay-dxp-tomcat-7.1.10.2-sp2-20190422172027516.zip \
 		"" \
 		dxp-10-7110
@@ -130,7 +130,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp3,7.1.10-dxp-15 \
+		7.1.10-dxp-15,7.1.10-sp3 \
 		files.liferay.com/private/ee/portal/7.1.10.3/liferay-dxp-tomcat-7.1.10.3-sp3-slim-20191118185746787.7z \
 		"" \
 		dxp-15-7110
@@ -145,7 +145,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp4,7.1.10-dxp-17 \
+		7.1.10-dxp-17,7.1.10-sp4 \
 		files.liferay.com/private/ee/portal/7.1.10.4/liferay-dxp-tomcat-7.1.10.4-sp4-slim-20200331093526761.7z \
 		"" \
 		dxp-17-7110
@@ -171,7 +171,7 @@ function build_images_dxp_72 {
 		dxp-1-7210
 
 	build_image \
-		7.2.10-sp1,7.2.10-dxp-2 \
+		7.2.10-dxp-2,7.2.10-sp1 \
 		files.liferay.com/private/ee/portal/7.2.10.1/liferay-dxp-tomcat-7.2.10.1-sp1-slim-20191009103614075.7z \
 		"" \
 		dxp-2-7210
@@ -196,7 +196,7 @@ function build_images_dxp_72 {
 		dxp-4-7210,security-dxp-4-202003-4-7210
 
 	build_image \
-		7.2.10-sp2,7.2.10-dxp-5 \
+		7.2.10-dxp-5,7.2.10-sp2 \
 		files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-slim-20200511121558464.7z \
 		"" \
 		dxp-5-7210,hotfix-1467-7210 \

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -57,7 +57,7 @@ function build_images_dxp_70 {
 	done
 
 	build_image \
-		7.0.10-sp13 \
+		7.0.10-sp13,7.0.10-de-90 \
 		files.liferay.com/private/ee/portal/7.0.10.13/liferay-dxp-digital-enterprise-tomcat-7.0.10.13-sp13-slim-20200310164407389.7z \
 		"" \
 		de-90-7010
@@ -100,7 +100,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp1 \
+		7.1.10-sp1,7.1.10-dxp-5 \
 		files.liferay.com/private/ee/portal/7.1.10.1/liferay-dxp-tomcat-7.1.10.1-sp1-20190110085705206.zip \
 		"" \
 		dxp-5-7110
@@ -115,7 +115,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp2 \
+		7.1.10-sp2,7.1.10-dxp-10 \
 		files.liferay.com/private/ee/portal/7.1.10.2/liferay-dxp-tomcat-7.1.10.2-sp2-20190422172027516.zip \
 		"" \
 		dxp-10-7110
@@ -130,7 +130,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp3 \
+		7.1.10-sp3,7.1.10-dxp-15 \
 		files.liferay.com/private/ee/portal/7.1.10.3/liferay-dxp-tomcat-7.1.10.3-sp3-slim-20191118185746787.7z \
 		"" \
 		dxp-15-7110
@@ -145,7 +145,7 @@ function build_images_dxp_71 {
 	done
 
 	build_image \
-		7.1.10-sp4 \
+		7.1.10-sp4,7.1.10-dxp-17 \
 		files.liferay.com/private/ee/portal/7.1.10.4/liferay-dxp-tomcat-7.1.10.4-sp4-slim-20200331093526761.7z \
 		"" \
 		dxp-17-7110
@@ -171,7 +171,7 @@ function build_images_dxp_72 {
 		dxp-1-7210
 
 	build_image \
-		7.2.10-sp1 \
+		7.2.10-sp1,7.2.10-dxp-2 \
 		files.liferay.com/private/ee/portal/7.2.10.1/liferay-dxp-tomcat-7.2.10.1-sp1-slim-20191009103614075.7z \
 		"" \
 		dxp-2-7210
@@ -196,7 +196,7 @@ function build_images_dxp_72 {
 		dxp-4-7210,security-dxp-4-202003-4-7210
 
 	build_image \
-		7.2.10-sp2 \
+		7.2.10-sp2,7.2.10-dxp-5 \
 		files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-slim-20200511121558464.7z \
 		"" \
 		dxp-5-7210,hotfix-1467-7210 \

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -70,11 +70,19 @@ function build_images_dxp_70 {
 		files.liferay.com/private/ee/fix-packs/7.0.10/hotfix/liferay-hotfix-6871-7010.zip
 
 	build_image \
+		7.0.10-security-de-91-202003-1 \
+		files.liferay.com/private/ee/portal/7.0.10-de-91/liferay-dxp-digital-enterprise-tomcat-7.0.10-de-91-20200420163527702.7z \
+		files.liferay.com/private/ee/fix-packs/7.0.10/security-de/liferay-security-de-91-202003-1-7010.zip \
+		de-91-7010,security-de-91-202003-1-7010
+
+	build_image \
 		7.0.10-de-92 \
 		files.liferay.com/private/ee/portal/7.0.10-de-92/liferay-dxp-digital-enterprise-tomcat-7.0.10-de-92-slim-20200519134012683.7z \
 		"" \
 		de-92-7010,hotfix-6854-7010 \
 		files.liferay.com/private/ee/fix-packs/7.0.10/hotfix/liferay-hotfix-6854-7010.zip
+
+
 }
 
 function build_images_dxp_71 {
@@ -143,6 +151,12 @@ function build_images_dxp_71 {
 		files.liferay.com/private/ee/portal/7.1.10.4/liferay-dxp-tomcat-7.1.10.4-sp4-slim-20200331093526761.7z \
 		"" \
 		dxp-17-7110
+
+	build_image \
+		7.1.10-security-dxp-17-202003-3 \
+		files.liferay.com/private/ee/portal/7.1.10.4/liferay-dxp-tomcat-7.1.10.4-sp4-20200331093526761.7z \
+		files.liferay.com/private/ee/fix-packs/7.1.10/security-dxp/liferay-security-dxp-17-202003-3-7110.zip \
+		dxp-17-7110,security-dxp-17-202003-3-7110
 }
 
 function build_images_dxp_72 {
@@ -178,11 +192,23 @@ function build_images_dxp_72 {
 		files.liferay.com/private/ee/fix-packs/7.2.10/hotfix/liferay-hotfix-1167-7210.zip
 
 	build_image \
+		7.2.10-security-dxp-4-202003-4 \
+		files.liferay.com/private/ee/portal/7.2.10-dxp-4/liferay-dxp-tomcat-7.2.10-dxp-4-20200121112425051.7z \
+		files.liferay.com/private/ee/fix-packs/7.2.10/security-dxp/liferay-security-dxp-4-202003-4-7210.zip \
+		dxp-4-7210,security-dxp-4-202003-4-7210
+
+	build_image \
 		7.2.10-sp2 \
 		files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-slim-20200511121558464.7z \
 		"" \
 		dxp-5-7210,hotfix-1467-7210 \
 		files.liferay.com/private/ee/fix-packs/7.2.10/hotfix/liferay-hotfix-1467-7210.zip
+
+	build_image \
+		7.2.10-security-dxp-5-202003-1 \
+		files.liferay.com/private/ee/portal/7.2.10.2/liferay-dxp-tomcat-7.2.10.2-sp2-20200511121558464.7z \
+		files.liferay.com/private/ee/fix-packs/7.2.10/security-dxp/liferay-security-dxp-5-202003-1-7210.zip \
+		dxp-5-7210,security-dxp-5-202003-1-7210
 }
 
 function main {

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -192,8 +192,8 @@ function main {
 
 	local release_file_urls=(
 		#releases.liferay.com/commerce/2.0.7/liferay-commerce-2.0.7-7.2.x-201912261227.7z
-		files.liferay.com/private/ee/commerce/2.1.0/liferay-commerce-enterprise-2.1.0-7.1.x-202005140921.7z
-		files.liferay.com/private/ee/commerce/2.1.0/liferay-commerce-enterprise-2.1.0-7.2.x-202005140933.7z
+		files.liferay.com/private/ee/commerce/2.1.1/liferay-commerce-enterprise-2.1.1-7.1.x-202006040810.7z
+		files.liferay.com/private/ee/commerce/2.1.1/liferay-commerce-enterprise-2.1.1-7.2.x-202006040818.7z
 		releases.liferay.com/portal/6.1.2-ga3/liferay-portal-tomcat-6.1.2-ce-ga3-20130816114619181.zip
 		files.liferay.com/private/ee/portal/6.1.30.5/liferay-portal-tomcat-6.1-ee-ga3-sp5-20160201142343123.zip
 		releases.liferay.com/portal/6.2.5-ga6/liferay-portal-tomcat-6.2-ce-ga6-20160112152609836.zip

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -81,8 +81,6 @@ function build_images_dxp_70 {
 		"" \
 		de-92-7010,hotfix-6854-7010 \
 		files.liferay.com/private/ee/fix-packs/7.0.10/hotfix/liferay-hotfix-6854-7010.zip
-
-
 }
 
 function build_images_dxp_71 {

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -188,6 +188,7 @@ function main {
 		releases.liferay.com/portal/7.1.3-ga4/liferay-ce-portal-tomcat-7.1.3-ga4-20190508171117552.7z
 		releases.liferay.com/portal/7.2.1-ga2/liferay-ce-portal-tomcat-7.2.1-ga2-20191111141448326.7z
 		releases.liferay.com/portal/7.3.2-ga3/liferay-ce-portal-tomcat-7.3.2-ga3-20200519164024819.7z
+		files.liferay.com/private/ee/portal/7.3.10-ep3/liferay-dxp-tomcat-7.3.10-ep3-20200522044030318.7z
 		#releases.liferay.com/portal/snapshot-7.1.x/201902130905/liferay-portal-tomcat-7.1.x.7z
 		#releases.liferay.com/portal/snapshot-master/201902131509/liferay-portal-tomcat-master.7z
 		#files.liferay.com/private/ee/portal/snapshot-ee-6.2.x/201808160944/liferay-portal-tomcat-ee-6.2.x.zip

--- a/build_image.sh
+++ b/build_image.sh
@@ -106,15 +106,23 @@ function build_docker_image {
 
 	DOCKER_IMAGE_TAGS=()
 
-	if [[ ${LIFERAY_DOCKER_RELEASE_FILE_URL%} == */snapshot-* ]]
-	then
-		DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}-${release_version}-${release_hash}")
-		DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}-$(date "${CURRENT_DATE}" "+%Y%m%d")")
-		DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}")
-	else
-		DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version}-${TIMESTAMP}")
-		DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version}")
-	fi
+	local default_ifs=${IFS}
+	IFS=","
+
+	for release_version_single in ${release_version}
+	do
+		if [[ ${LIFERAY_DOCKER_RELEASE_FILE_URL%} == */snapshot-* ]]
+		then
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}-${release_version_single}-${release_hash}")
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}-$(date "${CURRENT_DATE}" "+%Y%m%d")")
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}")
+		else
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}-${TIMESTAMP}")
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}")
+		fi
+	done
+
+	IFS=${default_ifs}
 
 	docker build \
 		--build-arg LABEL_BUILD_DATE=$(date "${CURRENT_DATE}" "+%Y-%m-%dT%H:%M:%SZ") \

--- a/build_image.sh
+++ b/build_image.sh
@@ -107,6 +107,7 @@ function build_docker_image {
 	DOCKER_IMAGE_TAGS=()
 
 	local default_ifs=${IFS}
+
 	IFS=","
 
 	for release_version_single in ${release_version}

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -10,9 +10,10 @@ RUN apk --no-cache add bash curl nss tomcat-native tree ttf-dejavu zulu11-jdk=11
 
 COPY scripts/* /usr/local/bin/
 
-RUN adduser -D -h /home/liferay liferay && addgroup liferay liferay
+RUN adduser -D -h /opt/liferay liferay && \
+	addgroup liferay liferay
 
-COPY --chown=liferay:liferay home/.bashrc /home/liferay/
+COPY --chown=liferay:liferay home/.bashrc /opt/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay
 
 ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -10,10 +10,9 @@ RUN apk --no-cache add bash curl nss tomcat-native tree ttf-dejavu zulu11-jdk=11
 
 COPY scripts/* /usr/local/bin/
 
-RUN adduser -D -h /opt/liferay liferay && \
-	addgroup liferay liferay
+RUN adduser -D -h /home/liferay liferay && addgroup liferay liferay
 
-COPY --chown=liferay:liferay home/.bashrc /opt/liferay/
+COPY --chown=liferay:liferay home/.bashrc /home/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay
 
 ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -10,7 +10,8 @@ RUN apk --no-cache add bash curl nss tomcat-native tree ttf-dejavu zulu11-jdk=11
 
 COPY scripts/* /usr/local/bin/
 
-RUN adduser -D -h /opt/liferay liferay && addgroup liferay liferay
+RUN adduser -D -h /opt/liferay liferay && \
+	addgroup liferay liferay
 
 COPY --chown=liferay:liferay home/.bashrc /opt/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -15,6 +15,8 @@ RUN adduser -D -h /home/liferay liferay && addgroup liferay liferay
 COPY --chown=liferay:liferay home/.bashrc /home/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay
 
+RUN ln -fs /opt/liferay/* /home/liferay
+
 ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh
 
 ENV JAVA_VERSION=zulu8

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -10,8 +10,7 @@ RUN apk --no-cache add bash curl nss tomcat-native tree ttf-dejavu zulu11-jdk=11
 
 COPY scripts/* /usr/local/bin/
 
-RUN adduser -D -h /opt/liferay liferay && \
-	addgroup liferay liferay
+RUN adduser -D -h /opt/liferay liferay && addgroup liferay liferay
 
 COPY --chown=liferay:liferay home/.bashrc /opt/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay

--- a/test_image.sh
+++ b/test_image.sh
@@ -172,7 +172,7 @@ function test_docker_image_scripts_2 {
 function test_health_status {
 	echo -en "Waiting for health status"
 
-	for counter in {1..90}
+	for counter in {1..200}
 	do
 		echo -en "."
 


### PR DESCRIPTION
The reason behind putting it into a separate RUN instruction is that the files have to be already present in /opt/liferay directory, so the following instructions must precede the linking:

```
RUN adduser -D -h /home/liferay liferay && addgroup liferay liferay

COPY --chown=liferay:liferay home/.bashrc /home/liferay/
COPY --chown=liferay:liferay liferay /opt/liferay
```