### PR TITLE
LRSUHU-2937

### DIFF
--- a/.releng/docker-image.changelog
+++ b/.releng/docker-image.changelog
@@ -683,3 +683,10 @@ docker.image.git.id-5.0.6=52c10db4ca5eab39e47fb874f4f59cef9812748d
 
 docker.image.change.log-5.0.7=DOCKER-165
 docker.image.git.id-5.0.7=35ebf0e35aa7aa6776316d95c3624540d0bfa378
+
+#
+# Liferay Docker Image Version 5.0.8
+#
+
+docker.image.change.log-5.0.8=DOCKER-169 DOCKER-166
+docker.image.git.id-5.0.8=3534021a069b22078f92c4a84e110301541d91b4

--- a/bundles.yml
+++ b/bundles.yml
@@ -410,13 +410,13 @@
         bundle_url: files.liferay.com/private/ee/portal/7.3.10-u19/liferay-dxp-tomcat-7.3.10.u19-20230104065351766.7z
         test_installed_patch: hotfix-6886-7310
         test_hotfix_url: files.liferay.com/private/ee/fix-packs/7.3.10/hotfix/liferay-hotfix-6886-7310.zip
-7.4.3.59:
-    7.4.3.59-ga59:
-        bundle_url: releases-cdn.liferay.com/portal/7.4.3.59-ga59/liferay-ce-portal-tomcat-7.4.3.59-ga59-20230112145006317.7z
+7.4.3.60:
+    7.4.3.60-ga60:
+        bundle_url: releases-cdn.liferay.com/portal/7.4.3.60-ga60/liferay-ce-portal-tomcat-7.4.3.60-ga60-20230119193525693.7z
         latest: true
 7.4.13:
-    7.4.13-u59:
-        bundle_url: releases-cdn.liferay.com/dxp/7.4.13-u59/liferay-dxp-tomcat-7.4.13.u59-20230112132719526.7z
+    7.4.13-u60:
+        bundle_url: releases-cdn.liferay.com/dxp/7.4.13-u60/liferay-dxp-tomcat-7.4.13.u60-20230119183106057.7z
         latest: true
     7.4.13.nightly:
         bundle_url: files.liferay.com/private/ee/portal/nightly/liferay-dxp-tomcat-7.4.13.nightly.7z

--- a/spinner/build.sh
+++ b/spinner/build.sh
@@ -8,6 +8,20 @@ function build_docker_images {
 }
 
 function check_usage {
+	function normalize_path(){
+		if [[ ! "${MSYSTEM}" =~ .*"MINGW".* ]]
+		then
+			echo ${1}
+
+			return
+		fi
+
+		path=${1}
+		normalized_path= echo ${path:1} | sed -r "s/(.{1})/\1:/"
+		
+		echo ${normalized_path}
+	}
+
 	check_utils docker
 
 	if [[ "${MSYSTEM}" =~ .*"MINGW".* ]] && [[ $MSYS_NO_PATHCONV -ne 1 ]]
@@ -54,7 +68,7 @@ function check_usage {
 	fi
 
 	STACK_NAME="env-${ENVIRONMENT}-"$(date +%s)
-	STACK_DIR=$(pwd)/${STACK_NAME}
+	STACK_DIR=$(normalize_path $(pwd)/${STACK_NAME})
 
 	mkdir -p "${STACK_DIR}"
 }


### PR DESCRIPTION
Fix issues with GitBash + Docker on Windows
Slack conversation: https://liferay.slack.com/archives/C04KDNY6CP8/p1674489442167989?thread_ts=1674116850.153549&cid=C04KDNY6CP8

Docker windows cannot digest this path that {pwd} provides ->
`/c/Users/zoltan.takacs/Repositories/liferay-docker/spinner/env-x1e4prd-1674489189/liferay`

We need to adjust the drive letter this way:
`c:/Users/zoltan.takacs/Repositories/liferay-docker/spinner/env-x1e4prd-1674490834/liferay`