### PR TITLE
SRE-2887 Add colon to the service's host only if port is defined

### DIFF
--- a/orca/scripts/build_services.sh
+++ b/orca/scripts/build_services.sh
@@ -451,11 +451,21 @@ function query_services {
 				then
 					if [ "${host}" == "localhost" ] || [ "${host}" == "${ORCA_HOST}" ]
 					then
-						item="${service}-${host}:${3}"
+						if [ -z ${3} ]
+						then
+							item="${service}-${host}"
+						else
+							item="${service}-${host}:${3}"
+						fi
 					else
 						local host_ip=$(query_configuration .hosts.${host}.ip ${host})
 
-						item="${host_ip}:${3}"
+						if [ -z ${3} ]
+						then
+							item="${host_ip}"
+						else
+							item="${host_ip}:${3}"
+						fi
 					fi
 				elif [ "${2}" == "service_name" ]
 				then


### PR DESCRIPTION
Currently, <host>:<port> for defining service relations. If port is not defined it defined as '<host>:' where the colon causes failure. Add colon to the host only if port is defined.