### PR TITLE
DOCKER-215

### DIFF
--- a/narwhal/release_notes/generate_release_notes.sh
+++ b/narwhal/release_notes/generate_release_notes.sh
@@ -20,7 +20,7 @@ function generate_release_notes {
 
 	local fixed_issues=$(git log "${ga_version}..${version}" --pretty=%s | grep -E "^[A-Z][A-Z0-9]*-[0-9]*" | sed -e "s/^\([A-Z][A-Z0-9]*-[0-9]*\).*/\\1/" | sort | uniq | grep -v POSHI | grep -v RELEASE | grep -v LRQA | grep -v LRCI | paste -sd,)
 
-	echo "UPDATE OSB_PatcherProjectVersion SET fixed_issues='${fixed_issues}' WHERE committish='${version}';" >> "${OUTPUT_FILE}"
+	echo "UPDATE OSB_PatcherProjectVersion SET fixedIssues='${fixed_issues}' WHERE committish='${version}';" >> "${OUTPUT_FILE}"
 }
 
 function main {

--- a/narwhal/release_notes/generate_release_notes.sh
+++ b/narwhal/release_notes/generate_release_notes.sh
@@ -14,11 +14,8 @@ function generate_release_notes {
 	if (echo "${version}" | grep -q "q")
 	then
 		ga_version=7.4.13-ga1
-	elif (echo "${version}" | grep -q "7.4")
-	then
-		ga_version=${version%%-u*}-ga1
 	else
-		ga_version=fix-pack-base-$(echo "${version%%-u*}" | sed -e s/[.]//g)
+		ga_version=${version%%-u*}-ga1
 	fi
 
 	local fixed_issues=$(git log "${ga_version}..${version}" --pretty=%s | grep -E "^[A-Z][A-Z0-9]*-[0-9]*" | sed -e "s/^\([A-Z][A-Z0-9]*-[0-9]*\).*/\\1/" | sort | uniq | grep -v POSHI | grep -v RELEASE | grep -v LRQA | grep -v LRCI | paste -sd,)

--- a/narwhal/release_notes/generate_release_notes.sh
+++ b/narwhal/release_notes/generate_release_notes.sh
@@ -18,7 +18,7 @@ function generate_release_notes {
 		ga_version=${version%%-u*}-ga1
 	fi
 
-	local fixed_issues=$(git log "${ga_version}..${version}" --pretty=%s | grep -E "^[A-Z][A-Z0-9]*-[0-9]*" | sed -e "s/^\([A-Z][A-Z0-9]*-[0-9]*\).*/\\1/" | sort | uniq | grep -v POSHI | grep -v RELEASE | grep -v LRQA | grep -v LRCI | paste -sd,)
+	local fixed_issues=$(git log "tags/${ga_version}..tags/${version}" --pretty=%s | grep -E "^[A-Z][A-Z0-9]*-[0-9]*" | sed -e "s/^\([A-Z][A-Z0-9]*-[0-9]*\).*/\\1/" | sort | uniq | grep -v POSHI | grep -v RELEASE | grep -v LRQA | grep -v LRCI | paste -sd,)
 
 	echo "UPDATE OSB_PatcherProjectVersion SET fixedIssues='${fixed_issues}' WHERE committish='${version}';" >> "${OUTPUT_FILE}"
 }

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -22,11 +22,15 @@ ARG TARGETPLATFORM
 
 COPY --chown=liferay:liferay liferay /opt/liferay/
 COPY --chown=liferay:liferay resources/opt/liferay/* /opt/liferay/
-COPY resources/usr/local/bin/* /usr/local/bin/
+COPY resources/usr/ /usr
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/liferay_entrypoint.sh"]
 
 ENV JPDA_ADDRESS=0.0.0.0:8000
+
+ENV CIDFSUBSTFONT="DroidSansFallback.ttf"
+ENV CIDFSUBSTPATH="/usr/share/fonts-droid-fallback/truetype/"
+ENV GS_LIB="/usr/share/fonts-droid-fallback/truetype/"
 
 ENV LIFERAY_CONTAINER_KILL_ON_FAILURE=0
 ENV LIFERAY_CONTAINER_STARTUP_LOCK_ENABLED=false


### PR DESCRIPTION
We should use a newer version of fallback CIDFont for Ghostscript 
- _Droid Sans Fallback Regular - Version 2.56 - https://eng.fontke.com/font/17404126/download/_

----

Ref: https://liferay.atlassian.net/browse/DOCKER-215